### PR TITLE
remote merge

### DIFF
--- a/checker.py
+++ b/checker.py
@@ -194,12 +194,19 @@ def merge_branches(rel_info):
   if experiment_branch is None:
     raise Exception("No experiment branch found for experiment %s" % (args.exp))
 
+  # refer to remote branch instead of local branch in case
+  # the branch is not checked out yet for some projects
+  experiment_branch = args.remote + '/' + experiment_branch
+
+  # assign the experiment branch to rel_info right now.
+  # otherwise, cleanup will not fail because of
+  # undefined field.
+  rel_info.experiment_branch = experiment_branch
+
   os.chdir(args.aosp_root)
 
   logger.info("Merging %s into %s" % (experiment_branch, rel_info.test_branch))
   utils.repo_forall('git merge %s -m "merge"' % (experiment_branch), verbose=args.verbose)
-
-  rel_info.experiment_branch = experiment_branch
 
 
 @time_it


### PR DESCRIPTION
In the merge stage, the checker will do a local merge of the experiment branch for all projects. But for me, I checkout the experiment branch only for three projects, so the other projects like (`abi/cpp`) do not have the experiment branch locally. The merge will fail for these other projects that because the experiment branch does not exist locally. I changed the script to do a remote merge.

Also when the merge stage fails, the cleanup routine will also fail because `rel_info.experiment_branch` has not been assigned yet. This will leave all the temporary branches in the repo. I'm not sure if this is an intentional behavior (so we can go to the temporary branch to check merge conflict) or not. I moved the assignment of `rel_info.experiment_branch` to be before calling merge.

```
CalledProcessError: Command 'GIT_PAGER= repo forall -epv -c git merge experiment/android-5.1.1_r3/XXX -m "merge"' returned non-zero exit status 1
Traceback (most recent call last):
  File "checker.py", line 247, in <module>
    main()
  File "/home/ryan/android/project.phonelab.platform_checker/utils.py", line 71, in func_wrapper
    func(*args, **kwargs)
  File "checker.py", line 242, in main
    cleanup(rel_info)
  File "checker.py", line 224, in cleanup
    utils.repo_forall('git checkout %s' % (rel_info.experiment_branch), verbose=args.verbose)
AttributeError: 'ReleaseInfo' object has no attribute 'experiment_branch'
```
